### PR TITLE
APIの二重送信を防ぐために、通信中はローディング表示する

### DIFF
--- a/src/app/shared/component/progress-spinner/progress-spinner.component.html
+++ b/src/app/shared/component/progress-spinner/progress-spinner.component.html
@@ -1,0 +1,1 @@
+<mat-progress-spinner mode="indeterminate"></mat-progress-spinner>

--- a/src/app/shared/component/progress-spinner/progress-spinner.component.spec.ts
+++ b/src/app/shared/component/progress-spinner/progress-spinner.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProgressSpinnerComponent } from './progress-spinner.component';
+
+describe('ProgressSpinnerComponent', () => {
+  let component: ProgressSpinnerComponent;
+  let fixture: ComponentFixture<ProgressSpinnerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ProgressSpinnerComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProgressSpinnerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/component/progress-spinner/progress-spinner.component.ts
+++ b/src/app/shared/component/progress-spinner/progress-spinner.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-progress-spinner',
+  templateUrl: './progress-spinner.component.html',
+  styleUrls: ['./progress-spinner.component.css'],
+})
+export class ProgressSpinnerComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/shared/interceptor/loading.interceptor.spec.ts
+++ b/src/app/shared/interceptor/loading.interceptor.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoadingInterceptor } from './loading.interceptor';
+
+describe('LoadingInterceptor', () => {
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      providers: [LoadingInterceptor],
+    })
+  );
+
+  it('should be created', () => {
+    const interceptor: LoadingInterceptor = TestBed.inject(LoadingInterceptor);
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/src/app/shared/interceptor/loading.interceptor.ts
+++ b/src/app/shared/interceptor/loading.interceptor.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { LoadingIndicatorService } from '../service/loading-indicator.service';
+
+@Injectable()
+export class LoadingInterceptor implements HttpInterceptor {
+  constructor(private loadingIndicatorService: LoadingIndicatorService) {}
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    const loadingRef = this.loadingIndicatorService.open();
+    return next.handle(request).pipe(finalize(() => loadingRef.close()));
+  }
+}

--- a/src/app/shared/service/loading-indicator.service.spec.ts
+++ b/src/app/shared/service/loading-indicator.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoadingIndicatorService } from './loading-indicator.service';
+
+describe('LoadingIndicatorService', () => {
+  let service: LoadingIndicatorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LoadingIndicatorService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/service/loading-indicator.service.ts
+++ b/src/app/shared/service/loading-indicator.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { Overlay } from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { ProgressSpinnerComponent } from '../component/progress-spinner/progress-spinner.component';
+
+export interface LoadingIndicatorRef {
+  close(): void;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LoadingIndicatorService {
+  constructor(private readonly overlay: Overlay) {}
+
+  open(): LoadingIndicatorRef {
+    const portal = new ComponentPortal(ProgressSpinnerComponent);
+    const overlayRef = this.overlay.create({
+      width: '100%',
+      height: '100%',
+      panelClass: 'app-loading-indicator',
+    });
+    overlayRef.attach(portal);
+    const close = () => {
+      overlayRef.detach();
+      overlayRef.dispose();
+    };
+    return {
+      close,
+    };
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -2,7 +2,8 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { MAT_DATE_LOCALE } from '@angular/material/core';
 
 // UI modules
 import { MatInputModule } from '@angular/material/input';
@@ -37,10 +38,14 @@ import { SidenavComponent } from './component/common/sidenav/sidenav.component';
 import { BreadcrumbComponent } from './component/common/breadcrumb/breadcrumb.component';
 import { TitleComponent } from './component/title/title.component';
 import { ConfirmDialogComponent } from './component/confirm-dialog/confirm-dialog.component';
+import { ProgressSpinnerComponent } from './component/progress-spinner/progress-spinner.component';
 
 // pipes
 import { UsernamePipe } from './pipe/username.pipe';
 import { DatetimePipe } from './pipe/datetime.pipe';
+
+// interceptors
+import { LoadingInterceptor } from './interceptor/loading.interceptor';
 
 @NgModule({
   declarations: [
@@ -52,6 +57,7 @@ import { DatetimePipe } from './pipe/datetime.pipe';
     BreadcrumbComponent,
     TitleComponent,
     ConfirmDialogComponent,
+    ProgressSpinnerComponent,
     UsernamePipe,
     DatetimePipe,
   ],
@@ -136,10 +142,16 @@ import { DatetimePipe } from './pipe/datetime.pipe';
     BreadcrumbComponent,
     TitleComponent,
     ConfirmDialogComponent,
+    ProgressSpinnerComponent,
 
     // pipes
     UsernamePipe,
     DatetimePipe,
+  ],
+
+  providers: [
+    { provide: MAT_DATE_LOCALE, useValue: 'ja-JP' },
+    { provide: HTTP_INTERCEPTORS, useClass: LoadingInterceptor, multi: true },
   ],
 })
 export class SharedModule {}

--- a/src/styles.css
+++ b/src/styles.css
@@ -142,3 +142,10 @@ body {
   margin-left: 10px;
   width: 200px;
 }
+
+.app-loading-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
This PR fixes #29 